### PR TITLE
Release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,15 @@
 All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## v0.1.0 (2024-09-17)
+
+[Full Changelog](https://github.com/main-branch/main_branch_shared_rubocop_config/compare/f01fd76..v0.1.0)
+
+Changes:
+
+* 450a0f6 Create a standard structure for keeping the gem version
+* dc7d7ea Add create_github_release as a development dependency
+* 3a2a26b Allow the config/ directory to be include in the gem.
+* 352792c Update installation and usage directions
+* f01fd76 Initial revision


### PR DESCRIPTION
# Release PR

## v0.1.0 (2024-09-17)

[Full Changelog](https://github.com/main-branch/main_branch_shared_rubocop_config/compare/f01fd76..v0.1.0)

Changes:

* 450a0f6 Create a standard structure for keeping the gem version
* dc7d7ea Add create_github_release as a development dependency
* 3a2a26b Allow the config/ directory to be include in the gem.
* 352792c Update installation and usage directions
* f01fd76 Initial revision
