### PR TITLE
Release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.1.1 (2024-10-04)
+
+[Full Changelog](https://github.com/main-branch/main_branch_shared_rubocop_config/compare/v0.1.0..v0.1.1)
+
+Changes since v0.1.0:
+
+* ed1f4ff Merge pull request #3 from main-branch/add_ci_build
+* 710b0c8 chore: add a continuous integration GitHub Actions workflow
+* 45f847e Merge pull request #2 from main-branch/add_dependencies
+* 7712cca chore: auto correct all rubocop offenses
+* d23fe2f chore: configure Rubocop to run on this project
+* d456481 chore: make git ignore Gemfile.lock
+* 58e5c44 fix: add needed runtime dependencies
+
 ## v0.1.0 (2024-09-17)
 
 [Full Changelog](https://github.com/main-branch/main_branch_shared_rubocop_config/compare/f01fd76..v0.1.0)

--- a/lib/main_branch_shared_rubocop_config/version.rb
+++ b/lib/main_branch_shared_rubocop_config/version.rb
@@ -3,5 +3,5 @@
 # Toplevel namespace for this gem
 module MainBranchSharedRubocopConfig
   # Version of this gem
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end


### PR DESCRIPTION
# Release PR

## v0.1.1 (2024-10-04)

[Full Changelog](https://github.com/main-branch/main_branch_shared_rubocop_config/compare/v0.1.0..v0.1.1)

Changes since v0.1.0:

* ed1f4ff Merge pull request #3 from main-branch/add_ci_build
* 710b0c8 chore: add a continuous integration GitHub Actions workflow
* 45f847e Merge pull request #2 from main-branch/add_dependencies
* 7712cca chore: auto correct all rubocop offenses
* d23fe2f chore: configure Rubocop to run on this project
* d456481 chore: make git ignore Gemfile.lock
* 58e5c44 fix: add needed runtime dependencies
