### PR TITLE
fix: do not trigger build workflows after merging to main or for release PRs

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -10,17 +10,18 @@ jobs:
   build:
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
 
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && !startsWith(github.event.pull_request.head.ref, 'release-please--'))
+
     runs-on: ${{ matrix.operating-system }}
     continue-on-error: true
 
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.3", "head"]
+        ruby: ["3.1", "3.4"]
         operating-system: [ubuntu-latest]
-        include:
-          - ruby: "3.0"
-            operating-system: windows-latest
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Since all merges to the main branch must be a fast-forward rebase, CI
builds should not be run when merged to main. They are run via the
pull request before merging.

The continuous_integration workflow should be triggered for pull requests
targeting main.

The experimental_ruby_builds workflow should only be triggered manually via
the GitHub UI.

Move unneeded builds from continuous_integration to experimental_ruby_builds

There is not a good reason to have a specific builds in the
continuous_integration workflow on Windows, or using JRuby or TruffleRuby.