### PR TITLE
build(dependencies): update dependencies for all GitHub Actions workflows

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,10 @@ jobs:
 
     steps:
       - name: Checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create release
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v5
         id: release
         with:
           token: ${{ secrets.AUTO_RELEASE_TOKEN }}


### PR DESCRIPTION
## Summary

Update GitHub Actions workflow dependencies to their latest major versions.

### Changes

| Action | Old | New | Latest release |
|--------|-----|-----|----------------|
| `actions/checkout` | `@v4` | `@v6` | v6.0.2 |
| `googleapis/release-please-action` | `@v4` | `@v5` | v5.0.0 |

### Already current

- `ruby/setup-ruby@v1` — latest is still v1 (v1.305.0)
- `rubygems/release-gem@v1` — latest is still v1 (v1.2.0)